### PR TITLE
Usb task delta time

### DIFF
--- a/src/hidboot.cpp
+++ b/src/hidboot.cpp
@@ -132,7 +132,7 @@ uint8_t KeyboardReportParser::HandleLockingKeys(HID *hid, uint8_t key)
 const uint8_t KeyboardReportParser::numKeys[] = { '!', '@', '#', '$', '%', '^', '&', '*', '(', ')' };
 const uint8_t KeyboardReportParser::symKeysUp[] = { '_', '+', '{', '}', '|', '~', ':', '"', '~', '<', '>', '?' };
 const uint8_t KeyboardReportParser::symKeysLo[] = { '-', '=', '[', ']', '\\', ' ', ';', '\'', '`', ',', '.', '/' };
-const uint8_t KeyboardReportParser::padKeys[] = { '/', '*', '-', '+', 0x13 };
+const uint8_t KeyboardReportParser::padKeys[] = { '/', '*', '-', '+', 0x0D };
 
 /**
  * \brief Manage keyboard OEM to ASCII conversion.
@@ -142,13 +142,34 @@ const uint8_t KeyboardReportParser::padKeys[] = { '/', '*', '-', '+', 0x13 };
  *
  * \return Keyboard corresponding ASCII value on success, 0 otherwise.
  */
+
+/* Key modifier bit map.
+ * 0 LEFT CTRL
+ * 1 LEFT SHIFT
+ * 2 LEFT ALT
+ * 3 LEFT GUI
+ * 4 RIGHT CTRL
+ * 5 RIGHT SHIFT
+ * 6 RIGHT ALT
+ * 7 RIGHT GUI
+ *
+ * shift = (mod & 0x22) means shift is non-zero
+ * 	if either or both shift keys are active
+ * ctrl  = (mod & 0x11) means ctrl is non-zero
+ * 	if either or both control keys are active
+ */
+
 uint8_t KeyboardReportParser::OemToAscii(uint8_t mod, uint8_t key)
 {
 	uint8_t shift = (mod & 0x22);
+	uint8_t ctrl  = (mod & 0x11);
 
 	// [a-z]
 	if (key > 0x03 && key < 0x1e)
 	{
+		// [^a-^z]
+		if (ctrl) return (key - 3);
+
 		// Upper case letters
 		if ( (kbdLockingKeys.kbdLeds.bmCapsLock == 0 && (mod & 2)) ||
 			 (kbdLockingKeys.kbdLeds.bmCapsLock == 1 && (mod & 2) == 0) )
@@ -162,7 +183,17 @@ uint8_t KeyboardReportParser::OemToAscii(uint8_t mod, uint8_t key)
 	else if (key > 0x1d && key < 0x27)
 	{
 		if (shift)
-			return (numKeys[key - 0x1e]);
+		{
+			if (ctrl)
+			{
+				if (key == 0x23)
+					return (0x1E);	/* RS ^^ */
+				else
+					return (0x00);
+			}
+			else
+				return (numKeys[key - 0x1e]);
+		}
 		else
 			return (key - 0x1e + '1');
 	}
@@ -173,7 +204,33 @@ uint8_t KeyboardReportParser::OemToAscii(uint8_t mod, uint8_t key)
 			return (key - 0x59 + '1');
 	}
 	else if (key > 0x2c && key < 0x39)
-		return ((shift) ? symKeysUp[key-0x2d] : symKeysLo[key-0x2d]);
+	{
+		if (shift)
+		{
+			if (ctrl)
+			{
+				if (key == 0x2d)
+					return (0x1F);	/* US ^_ */
+				else
+					return (0x00);
+			}
+			else
+				return symKeysUp[key-0x2d];
+		}
+		else
+		{
+			if (ctrl)
+				switch (key)
+				{
+					case 0x2F:	return 0x1B;	/* ESC ^[ */
+					case 0x31:	return 0x1C;	/* FS  ^\ */
+					case 0x30:	return 0x1D;	/* GS  ^] */
+					default:	return 0x00;
+				}
+			else
+				return symKeysLo[key-0x2d];
+		}
+	}
 	else if (key > 0x53 && key < 0x59)
 		return padKeys[key - 0x54];
 	else
@@ -181,7 +238,11 @@ uint8_t KeyboardReportParser::OemToAscii(uint8_t mod, uint8_t key)
 		switch (key)
 		{
 			case KEY_SPACE:		return (0x20);
-			case KEY_ENTER:		return (0x13);
+			case KEY_ENTER:		return (0x0D);
+			case KEY_ESCAPE:	return (0x1B);
+			case KEY_DELETE:	return (0x08);
+			case KEY_DELETE_FORWARD: return (0x7F);	// ASCII DEL
+			case KEY_TAB:		return (0x09);
 			case KEY_ZERO:		return ((shift) ? ')' : '0');
 			case KEY_ZERO2:		return ((kbdLockingKeys.kbdLeds.bmNumLock == 1) ? '0' : 0);
 			case KEY_PERIOD:	return ((kbdLockingKeys.kbdLeds.bmNumLock == 1) ? '.' : 0);

--- a/src/hidboot.h
+++ b/src/hidboot.h
@@ -29,6 +29,10 @@ e-mail   :  support@circuitsathome.com
 #define KEY_ZERO					0x27
 #define KEY_ZERO2					0x62
 #define KEY_ENTER					0x28
+#define KEY_ESCAPE					0x29
+#define KEY_DELETE					0x2A	// Backspace
+#define KEY_DELETE_FORWARD			0x4C	// Delete
+#define KEY_TAB   					0x2B
 #define KEY_PERIOD					0x63
 
 /**


### PR DESCRIPTION
This fix changes the delay time calculations in USBHost::Task() to use a delta time rather than the absolute time from millis(), changing the definition of the 'delay' variable to be the number of milliseconds remaining rather than an absolute time "on the clock".

This resolves two issues:
1. Calculation issues when the millis() clock rolls over to 0, which previously caused the comparison between delay and millis() to yield incorrect results.
2. Long USB I/O delays caused when Task() isn't called sufficiently often enough.

This change is in conjunction with the discussion for issue arduino-libraries/USBHost#2.
