### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/MouseController/MouseController.ino
+++ b/examples/MouseController/MouseController.ino
@@ -22,9 +22,9 @@ USBHost usb;
 MouseController mouse(usb);
 
 // variables for mouse button states
-boolean leftButton = false;
-boolean middleButton = false;
-boolean rightButton = false;
+bool leftButton = false;
+bool middleButton = false;
+bool rightButton = false;
 
 // This function intercepts mouse movements
 void mouseMoved() {


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633