### PR TITLE
Use GitHub Actions for continuous integration

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = configued,wan,sav,hist
+check-filenames =
+check-hidden =
+skip = ./.git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -1,0 +1,28 @@
+name: Check Arduino
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          compliance: specification
+          library-manager: update
+          # Always use this setting for official repositories. Remove for 3rd party projects.
+          official: true
+          project-type: library

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -25,6 +25,9 @@ jobs:
     name: ${{ matrix.board.fqbn }}
     runs-on: ubuntu-latest
 
+    env:
+      SKETCHES_REPORTS_PATH: sketches-reports
+
     strategy:
       fail-fast: false
 
@@ -51,3 +54,12 @@ jobs:
             # See: https://github.com/arduino/compile-sketches#libraries
           sketch-paths: |
             - examples
+          enable-deltas-report: true
+          sketches-report-path: ${{ env.SKETCHES_REPORTS_PATH }}
+
+      - name: Save sketches report as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          if-no-files-found: error
+          path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,0 +1,53 @@
+name: Compile Examples
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/compile-examples.yml"
+      - "library.properties"
+      - "examples/**"
+      - "src/**"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by changes to external resources (libraries, platforms).
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.board.fqbn }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        board:
+          - fqbn: arduino:sam:arduino_due_x_dbg
+            platforms: |
+              - name: arduino:sam
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fqbn: ${{ matrix.board.fqbn }}
+          platforms: ${{ matrix.board.platforms }}
+          libraries: |
+            # Install the library from the local path.
+            - source-path: ./
+            # Additional library dependencies can be listed here.
+            # See: https://github.com/arduino/compile-sketches#libraries
+          sketch-paths: |
+            - examples

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.yml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@
 = {repository-name} Library for Arduino =
 
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml/badge.svg["Compile Examples status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/compile-examples.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 The USBHost library allows an Arduino Due board to appear as a USB host, enabling it to communicate with peripherals like USB mice and keyboards.

--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,7 @@
 
 = {repository-name} Library for Arduino =
 
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml/badge.svg["Check Arduino status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/check-arduino.yml"]
 image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 The USBHost library allows an Arduino Due board to appear as a USB host, enabling it to communicate with peripherals like USB mice and keyboards.

--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,14 @@
-= USB Host Library for Arduino =
+:repository-owner: arduino-libraries
+:repository-name: USBHost
+
+= {repository-name} Library for Arduino =
+
+image:https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml/badge.svg["Spell Check status", link="https://github.com/{repository-owner}/{repository-name}/actions/workflows/spell-check.yml"]
 
 The USBHost library allows an Arduino Due board to appear as a USB host, enabling it to communicate with peripherals like USB mice and keyboards.
 
 For more information about this library please visit us at
-http://www.arduino.cc/en/Reference/USBHost
+http://www.arduino.cc/en/Reference/{repository-name}
 
 == License ==
 

--- a/examples/ADKTerminalTest/ADKTerminalTest.ino
+++ b/examples/ADKTerminalTest/ADKTerminalTest.ino
@@ -7,7 +7,7 @@
 
  The ADK for the Arduino Due is a work in progress
  For additional information on the Arduino ADK visit
- http://labs.arduino.cc/ADK/Index
+ https://web.archive.org/web/20170503104018/http://labs.arduino.cc/ADK/Index
 
  created 27 June 2012
  by Cristian Maglie

--- a/src/Usb.cpp
+++ b/src/Usb.cpp
@@ -253,7 +253,7 @@ uint32_t USBHost::ctrlReq(uint32_t addr, uint32_t ep, uint8_t bmReqType, uint8_t
 				if (rcode)
 					return rcode;
 
-				// Invoke callback function if inTransfer completed successfuly and callback function pointer is specified
+				// Invoke callback function if inTransfer completed successfully and callback function pointer is specified
 				if (!rcode && p)
 					((USBReadParser*)p)->Parse(read, dataptr, total - left);
 
@@ -821,7 +821,7 @@ void USBHost::Task(void)
 				{
 					TRACE_USBHOST(printf(" + USB_ATTACHED_SUBSTATE_WAIT_SOF\r\n");)
 
-					// 20ms waiting elapsed
+					// 20 ms waiting elapsed
 					usb_task_state = USB_STATE_CONFIGURING;
 				}
             }

--- a/src/Usb.h
+++ b/src/Usb.h
@@ -73,7 +73,7 @@ e-mail   :  support@circuitsathome.com
 
 #define USB_NUMDEVICES			16		//number of USB devices
 //#define HUB_MAX_HUBS			7		// maximum number of hubs that can be attached to the host controller
-#define HUB_PORT_RESET_DELAY	20		// hub port reset delay 10 ms recomended, can be up to 20 ms
+#define HUB_PORT_RESET_DELAY	20		// hub port reset delay 10 ms recommended, can be up to 20 ms
 
 /* USB state machine states */
 #define USB_STATE_MASK                                      0xf0

--- a/src/address.h
+++ b/src/address.h
@@ -36,7 +36,7 @@ e-mail   :  support@circuitsathome.com
  *
  * \note The number of host pipe is limited by the hardware (10 on SAM3X).
  * Moreover hostPipeNum allocation is static, meaning that only a limited
- * amount of device endpoints can be opened at the same time, thus limitating
+ * amount of device endpoints can be opened at the same time, thus limiting
  * the maximum number of connected devices at the same time.
  */
 struct EpInfo
@@ -81,7 +81,7 @@ struct UsbDeviceAddress
 			uint32_t		bmAddress	: 3;	// device address/port number
 			uint32_t		bmParent	: 3;	// parent hub address
 			uint32_t		bmHub		: 1;	// hub flag
-			uint32_t		bmReserved	: 25;	// reserved, must be zerro
+			uint32_t		bmReserved	: 25;	// reserved, must be zero
 		};
 		uint32_t	devAddress;
 	};
@@ -154,7 +154,7 @@ private:
 	};
 
 	/**
-	 * \brief Return an address pool index for a given  address. This index can
+	 * \brief Return an address pool index for a given address. This index can
 	 * further be used to retrieve the corresponding USB device instance
 	 * UsbDevice.
 	 *
@@ -179,8 +179,8 @@ private:
 	 * UsbDevice.
 	 *
 	 * \param addr Parent USB address.
-	 * \param start Search in the pool from this index. Calling multiple time
-	 * this function with the returned index + 1 can be used to walk through
+	 * \param start Search in the pool from this index. Calling this function
+	 * multiple times with the returned index + 1 can be used to walk through
 	 * all children.
 	 *
 	 * \return Child index number if found, 0 otherwise.
@@ -201,7 +201,7 @@ private:
 	 * \brief Free address entry specified by index parameter.
 	 *
 	 * \note Calling FreeAddressByIndex only frees the USB address for possible
-	 * further assignement. However, it does not free the actual USB resources
+	 * further assignment. However, it does not free the actual USB resources
 	 * used by the device. This can be made by calling the release() method
 	 * from any UsbDevice class implementing USBDeviceConfig.
 	 *
@@ -249,7 +249,7 @@ public:
 		// Init address zero (reserved)
 		InitEntry(0);
 
-		// Init all remaing addresses
+		// Init all remaining addresses
 		InitAllAddresses();
 
 		// Configure ep0 used for enumeration
@@ -370,7 +370,7 @@ public:
 	};
 
 	// Returns number of hubs attached
-	// It can be rather helpfull to find out if there are hubs attached than getting the exact number of hubs.
+	// It can be rather helpful to find out if there are hubs attached than getting the exact number of hubs.
 	/*uint32_t GetNumHubs()
 	{
 		return hubCounter;

--- a/src/adk.cpp
+++ b/src/adk.cpp
@@ -200,7 +200,7 @@ uint32_t ADK::Init(uint32_t parent, uint32_t port, uint32_t lowspeed)
 
 		if (bNumEP == 3)
 		{
-			// Assign epInfo to epinfo pointer - this time all 3 endpoins
+			// Assign epInfo to epinfo pointer - this time all 3 endpoints
 			rcode = pUsb->setEpInfoEntry(bAddress, 3, epInfo);
 			if (rcode)
 			{

--- a/src/confdescparser.h
+++ b/src/confdescparser.h
@@ -56,7 +56,7 @@ class ConfigDescParser : public USBReadParser
 	uint32_t				dscrLen;			// Descriptor length
 	uint32_t				dscrType;			// Descriptor type
 
-	bool					isGoodInterface;	// Apropriate interface flag
+	bool					isGoodInterface;	// Appropriate interface flag
 	uint32_t				confValue;			// Configuration value
 	uint32_t				protoValue;			// Protocol value
 	uint32_t				ifaceNumber;		// Interface number
@@ -145,7 +145,7 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
 			// This is a sort of hack. Assuming that two bytes are already in the buffer
 			//	the pointer is positioned two bytes ahead in order for the rest of descriptor
 			//	to be read right after the size and the type fields.
-			// This should be used carefuly. varBuffer should be used directly to handle data
+			// This should be used carefully. varBuffer should be used directly to handle data
 			//	in the buffer.
 			theBuffer.pValue	= varBuffer + 2;
 			stateParseDescr		= 3;

--- a/src/hidboot.cpp
+++ b/src/hidboot.cpp
@@ -98,7 +98,7 @@ void KeyboardReportParser::Parse(HID *hid, bool is_rpt_id, uint32_t len, uint8_t
 };
 
 /**
- * \brief Handle keyboard locking keys and manage keyboard leds using USB
+ * \brief Handle keyboard locking keys and manage keyboard LEDs using USB
  * report.
  *
  * \param hid HID device pointer.


### PR DESCRIPTION
This PR provides the standardized [GitHub Actions](https://github.com/features/actions)-based CI configuration for Arduino libraries.

### Dependabot

Dependabot will periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

NOTE: Dependabot's PRs will sometimes try to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/en/actions/creating-actions/about-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump. So even if the PRs from Dependabot are not always exactly correct, their value lies in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot

### Spell check

On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.

### Arduino Lint

On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

### Compile examples

On every push or pull request that affects library source or example files, and periodically, use [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) to compile all example sketches for the specified boards.

### Report size deltas

On creation or commit to a pull request, use [the `arduino/report-size-deltas` action](https://github.com/arduino/report-size-deltas) to comment a report of the resulting change in memory usage of the examples to the PR thread.

---
Fixes https://github.com/arduino-libraries/USBHost/issues/27