### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = configued,wan,sav,hist
+ignore-words-list = configued,wan,sav,hist,tabl
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
In the latest release of [the **codespell** tool](https://github.com/codespell-project/codespell) used for automated spell checking of the files of this project, the word "tabl" was added to the codespell misspelled words dictionary as a misspelling of "table".

This work occurs in a string in the library's source code, which causes the spell check to fail:

https://github.com/arduino-libraries/USBHost/runs/8087220577?check_suite_focus=true#step:4:16

```text
Error: ./src/hidusagestr.h:808: Tabl ==> Table
1
Codespell found one or more problems
```

Although it is not clear to me what the purpose of this string is, I will assume it is correct and intended as it is. For this reason, the false positive is resolved by configuring codespell to ignore the problematic word.