### PR TITLE
Adjust spell checker configuration to fix false positive

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = configued,wan,sav,hist,tabl
+ignore-words-list = configued,secur,wan,sav,hist,tabl
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) tool is used for automated detection of common misspellings in the files of this project.

A [new release](https://github.com/codespell-project/codespell/releases/tag/v2.2.6) of codespell includes an expansion of its misspellings dictionary. One of the additions is "secur" as a misspelling of "secure". The word "secur" occurs in the library's codebase:

https://github.com/arduino-libraries/USBHost/actions/runs/6390269849/job/17343187744#step:4:17

```text
Error: ./src/hidusagestr.h:474: Secur ==> Secure
Error: ./src/hidusagestr.h:539: Secur ==> Secure
```

Although it is not clear why the author of that code felt the need to shorten the words, the prevalence of such shortening clearly indicates it was done on purpose so this is a false positive.

The false positive is fixed by adding "secur" to the ignored words list in the codespell configuration file.