### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = configued,secur,wan,sav,hist,tabl
+ignore-words-list = configued,interruptin,secur,wan,sav,hist,tabl
 check-filenames =
 check-hidden =
 skip = ./.git


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.3.0) of codespell. Some of the text in the project codebase happens to match against newly added entries, which caused **codespell** to produce a false misspelled word detection:

https://github.com/arduino-libraries/USBHost/actions/runs/9265658748

> spellcheck: src/hid.h#L172
InterruptIN ==> interrupting, interrupt in, interruption

Since the code that produced the detection is correct and intended, the false positive is resolved by [configuring](https://github.com/codespell-project/codespell#using-a-config-file) **codespell** to ignore the problematic word.

